### PR TITLE
Add squad name to XWS output

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -35,7 +35,7 @@ app.use bodyparser.json()
 
 app.get '/', (req, res) ->
     if req.query.f? and req.query.d?
-        xws_obj = xws.serializedToXWS req.query.f, req.query.d
+        xws_obj = xws.serializedToXWS req.query.f, req.query.d, req.query.sn
         xws_obj.vendor.yasb.link = "https://geordanr.github.io/xwing#{req.originalUrl}"
         res.json xws_obj
     else

--- a/xws.coffee
+++ b/xws.coffee
@@ -31,7 +31,7 @@ fromXWSUpgrade =
 
 exportObj = exports ? this
 
-exportObj.serializedToXWS = (faction, serialized) ->
+exportObj.serializedToXWS = (faction, serialized, name) ->
     xws =
         faction: toXWSFaction[faction]
         pilots: []
@@ -41,6 +41,9 @@ exportObj.serializedToXWS = (faction, serialized) ->
                 builder_url: 'https://geordanr.github.io/xwing'
                 link: 'https://geordanr.github.io/xwing'
         version: XWS_VERSION
+
+    if name?.length and name != 'Unnamed Squadron'
+      xws.name = name
 
     for ship in permalink.serializedToShips faction, serialized
         continue unless ship?.pilot?


### PR DESCRIPTION
This will add the squad name to the XWS output. In an upcoming Vassal module this name will be shown in chat after the list has loaded ([link](https://github.com/Mu0n/HWpopup/pull/8)).

Example of how it'll look in Vassal:
![list name in vassal chat](https://cloud.githubusercontent.com/assets/834902/22963751/e9b5e72a-f354-11e6-95bb-c1db66d99fa8.png)