### PR TITLE
Export obstacles when available

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -35,7 +35,12 @@ app.use bodyparser.json()
 
 app.get '/', (req, res) ->
     if req.query.f? and req.query.d?
-        xws_obj = xws.serializedToXWS req.query.f, req.query.d, req.query.sn
+        xws_obj = xws.serializedToXWS {
+          faction: req.query.f
+          serialized: req.query.d
+          name: req.query.sn
+          obstacles: req.query.obs
+        }
         xws_obj.vendor.yasb.link = "https://geordanr.github.io/xwing#{req.originalUrl}"
         res.json xws_obj
     else

--- a/xws.coffee
+++ b/xws.coffee
@@ -31,7 +31,7 @@ fromXWSUpgrade =
 
 exportObj = exports ? this
 
-exportObj.serializedToXWS = (faction, serialized, name) ->
+exportObj.serializedToXWS = ({faction, serialized, name, obstacles}) ->
     xws =
         faction: toXWSFaction[faction]
         pilots: []
@@ -44,6 +44,11 @@ exportObj.serializedToXWS = (faction, serialized, name) ->
 
     if name?.length and ['Unnamed Squadron', 'New Squadron'].indexOf(name) == -1
       xws.name = name
+
+    if obstacles
+      obs = obstacles.split(',')
+      if obs.length == 3
+        xws.obstacles = obs
 
     for ship in permalink.serializedToShips faction, serialized
         continue unless ship?.pilot?


### PR DESCRIPTION
I saw that you added obstacles to your builder. We'd like to add support for obstacles in the autospawner in Vassal. To do that we'd need to have them in the xws as well.

This pr will add an `obstacles` field to the XWS export if the `obs` param is specified and has exactly 3 strings. There is no validation yet on whether the strings are valid obstacles according to the xws spec.

Link to test with:
`https://yasb-xws.herokuapp.com/?f=Scum%20and%20Villainy&d=v4!s!171:98,136,-1,174,182,128:29:12:;173:18,-1,-1,179,180,112:-1:3:&sn=Unsaved%20Squadron&obs=coreasteroid1,yt2400debris0,core2asteroid2`